### PR TITLE
Move CrazyData from Board to History

### DIFF
--- a/core/src/main/scala/Board.scala
+++ b/core/src/main/scala/Board.scala
@@ -6,11 +6,7 @@ import variant.{ Crazyhouse, Variant }
 import bitboard.Board as BBoard
 import bitboard.Bitboard
 
-case class Board(
-    board: BBoard,
-    history: History,
-    variant: Variant
-):
+case class Board(board: BBoard, history: History, variant: Variant):
 
   export history.{ castles, unmovedRooks, crazyData }
   export board.{
@@ -77,9 +73,7 @@ case class Board(
   def promote(orig: Square, dest: Square, piece: Piece): Option[Board] =
     board.promote(orig, dest, piece).map(withBoard)
 
-  def withHistory(h: History): Board = copy(history = h)
-
-  def withCastles(c: Castles) = withHistory(history.withCastles(c))
+  def withCastles(c: Castles) = updateHistory(_.withCastles(c))
 
   def withPieces(newPieces: PieceMap) = copy(board = BBoard.fromMap(newPieces))
 

--- a/core/src/main/scala/Board.scala
+++ b/core/src/main/scala/Board.scala
@@ -46,13 +46,6 @@ case class Board(board: BBoard, history: History, variant: Variant):
   inline def apply(inline at: Square): Option[Piece]     = board.pieceAt(at)
   inline def apply(inline file: File, inline rank: Rank) = board.pieceAt(Square(file, rank))
 
-  def checkColor: Option[Color] = checkWhite.yes.option(White).orElse(checkBlack.yes.option(Black))
-
-  lazy val checkWhite: Check = checkOf(White)
-  lazy val checkBlack: Check = checkOf(Black)
-
-  def checkOf(c: Color): Check = variant.kingThreatened(this, c)
-
   def withBoard(b: BBoard): Board = copy(board = b)
 
   def place(piece: Piece, at: Square): Option[Board] =

--- a/core/src/main/scala/History.scala
+++ b/core/src/main/scala/History.scala
@@ -1,5 +1,7 @@
 package chess
 
+import chess.variant.Crazyhouse
+
 import format.Uci
 
 // Checks received by the respective side.
@@ -21,7 +23,8 @@ case class History(
     castles: Castles = Castles.init,
     checkCount: CheckCount = CheckCount(0, 0),
     unmovedRooks: UnmovedRooks,
-    halfMoveClock: HalfMoveClock = HalfMoveClock.initial
+    halfMoveClock: HalfMoveClock = HalfMoveClock.initial,
+    crazyData: Option[Crazyhouse.Data]
 ):
 
   def setHalfMoveClock(v: HalfMoveClock) = copy(halfMoveClock = v)
@@ -50,4 +53,8 @@ case class History(
 object History:
 
   def castle(color: Color, kingSide: Boolean, queenSide: Boolean) =
-    History(castles = Castles.init.update(color, kingSide, queenSide), unmovedRooks = UnmovedRooks.corners)
+    History(
+      castles = Castles.init.update(color, kingSide, queenSide),
+      unmovedRooks = UnmovedRooks.corners,
+      crazyData = None
+    )

--- a/core/src/main/scala/History.scala
+++ b/core/src/main/scala/History.scala
@@ -49,12 +49,3 @@ case class History(
     if check.yes then copy(checkCount = checkCount.add(color)) else this
 
   def withCheckCount(cc: CheckCount) = copy(checkCount = cc)
-
-object History:
-
-  def castle(color: Color, kingSide: Boolean, queenSide: Boolean) =
-    History(
-      castles = Castles.init.update(color, kingSide, queenSide),
-      unmovedRooks = UnmovedRooks.corners,
-      crazyData = None
-    )

--- a/core/src/main/scala/MoveOrDrop.scala
+++ b/core/src/main/scala/MoveOrDrop.scala
@@ -129,8 +129,6 @@ case class Move(
   val isWhiteTurn: Boolean = piece.color.white
   inline def color         = piece.color
 
-  inline def withHistory(inline h: History) = copy(after = after.withHistory(h))
-
   def withPromotion(op: Option[PromotableRole]): Option[Move] =
     op.fold(this.some)(withPromotion)
 
@@ -187,8 +185,6 @@ case class Drop(
         if h.positionHashes.value.isEmpty then PositionHash(Hash(situationBefore)) else h.positionHashes
       h.copy(positionHashes = PositionHash(Hash(Situation(board, !piece.color))).combine(basePositionHashes))
     }
-
-  inline def withHistory(inline h: History) = copy(after = after.withHistory(h))
 
   def afterWithLastMove: Board =
     after.variant.finalizeBoard(

--- a/core/src/main/scala/Situation.scala
+++ b/core/src/main/scala/Situation.scala
@@ -25,7 +25,8 @@ case class Situation(board: Board, color: Color):
       case v: Crazyhouse.type => v.possibleDrops(this)
       case _                  => None
 
-  lazy val check: Check = board.checkOf(color)
+  lazy val check: Check               = checkOf(color)
+  inline def checkOf(c: Color): Check = variant.kingThreatened(board, c)
 
   def checkSquare: Option[Square] = if check.yes then ourKing else None
 

--- a/core/src/main/scala/Situation.scala
+++ b/core/src/main/scala/Situation.scala
@@ -64,8 +64,8 @@ case class Situation(board: Board, color: Color):
   def drop(role: Role, square: Square): Either[ErrorStr, Drop] =
     variant.drop(this, role, square)
 
-  def withHistory(history: History): Situation =
-    copy(board = board.withHistory(history))
+  inline def updateHistory(inline f: History => History) =
+    copy(board = board.updateHistory(f))
 
   def withVariant(variant: chess.variant.Variant): Situation =
     copy(board = board.withVariant(variant))

--- a/core/src/main/scala/bitboard/Board.scala
+++ b/core/src/main/scala/bitboard/Board.scala
@@ -6,11 +6,8 @@ import cats.syntax.all.*
 import Bitboard.*
 
 // Chess board representation
-case class Board(
-    occupied: Bitboard,
-    byColor: ByColor,
-    byRole: ByRole
-):
+case class Board(occupied: Bitboard, byColor: ByColor, byRole: ByRole):
+
   val white   = byColor.white
   val black   = byColor.black
   val pawns   = byRole.pawn

--- a/core/src/main/scala/format/BinaryFen.scala
+++ b/core/src/main/scala/format/BinaryFen.scala
@@ -178,7 +178,7 @@ object BinaryFen:
     write(
       Situation.AndFullMoveNumber(
         situation
-          .withHistory(situation.history.setHalfMoveClock(HalfMoveClock.initial))
+          .updateHistory(_.setHalfMoveClock(HalfMoveClock.initial))
           .withVariant(situation.variant match
             case Standard | Chess960 | FromPosition => Standard
             case other                              => other),

--- a/core/src/main/scala/format/BinaryFen.scala
+++ b/core/src/main/scala/format/BinaryFen.scala
@@ -155,10 +155,10 @@ case class BinaryFen(value: Array[Byte]) extends AnyVal:
             castles =
               maximumCastles(unmovedRooks = unmovedRooks, white = white, black = black, kings = kings),
             unmovedRooks = unmovedRooks,
-            halfMoveClock = halfMoveClock
+            halfMoveClock = halfMoveClock,
+            crazyData = crazyData
           ),
-          variant,
-          crazyData
+          variant
         ),
         color = turn
       ),

--- a/core/src/main/scala/format/FenReader.scala
+++ b/core/src/main/scala/format/FenReader.scala
@@ -57,7 +57,7 @@ trait FenReader:
       yield Uci.Move(orig, dest)
 
       situation.withHistory:
-        val history = History(
+        val history = situation.history.copy(
           lastMove = enpassantMove,
           positionHashes = PositionHash.empty,
           castles = castles,

--- a/core/src/main/scala/format/FenReader.scala
+++ b/core/src/main/scala/format/FenReader.scala
@@ -21,7 +21,7 @@ trait FenReader:
     makeBoard(variant, fBoard).map { board =>
       // We trust Fen's color to be correct, if there is no color we use the color of the king in check
       // If there is no king in check we use white
-      val color     = fColor.orElse(board.checkColor) | Color.White
+      val color     = fColor.orElse(variant.checkColor(board)) | Color.White
       val situation = Situation(board, color)
       // todo verify unmovedRooks vs board.rooks
       val (castles, unmovedRooks) =

--- a/core/src/main/scala/format/FenReader.scala
+++ b/core/src/main/scala/format/FenReader.scala
@@ -56,8 +56,8 @@ trait FenReader:
           situation.board(orig).isEmpty
       yield Uci.Move(orig, dest)
 
-      situation.withHistory:
-        val history = situation.history.copy(
+      situation.updateHistory: original =>
+        val history = original.copy(
           lastMove = enpassantMove,
           positionHashes = PositionHash.empty,
           castles = castles,
@@ -78,7 +78,7 @@ trait FenReader:
     read(variant, fen).map { sit =>
       val (halfMoveClock, fullMoveNumber) = readHalfMoveClockAndFullMoveNumber(fen)
       Situation.AndFullMoveNumber(
-        halfMoveClock.map(sit.history.setHalfMoveClock).fold(sit)(sit.withHistory),
+        halfMoveClock.map(sit.history.setHalfMoveClock).fold(sit)(x => sit.updateHistory(_ => x)),
         fullMoveNumber | FullMoveNumber(1)
       )
     }

--- a/core/src/main/scala/variant/Crazyhouse.scala
+++ b/core/src/main/scala/variant/Crazyhouse.scala
@@ -43,7 +43,7 @@ case object Crazyhouse
         .place(piece, square)
         .toRight(ErrorStr(s"Can't drop $role on $square, it's occupied"))
       _ <- Either.cond(
-        b1.checkOf(situation.color).no,
+        kingThreatened(b1, situation.color).no,
         b1,
         ErrorStr(s"Dropping $role on $square doesn't uncheck the king")
       )

--- a/core/src/main/scala/variant/ThreeCheck.scala
+++ b/core/src/main/scala/variant/ThreeCheck.scala
@@ -25,7 +25,7 @@ case object ThreeCheck
 
   override def finalizeBoard(board: Board, uci: format.Uci, capture: Option[Piece]): Board =
     board.updateHistory:
-      _.withCheck(Color.White, board.checkWhite).withCheck(Color.Black, board.checkBlack)
+      _.withCheck(Color.White, checkWhite(board)).withCheck(Color.Black, checkBlack(board))
 
   override def specialEnd(situation: Situation) =
     situation.check.yes && {

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -54,6 +54,12 @@ abstract class Variant private[variant] (
   def kingThreatened(board: Board, color: Color): Check =
     board.isCheck(color)
 
+  def checkWhite(board: Board): Check = kingThreatened(board, White)
+  def checkBlack(board: Board): Check = kingThreatened(board, Black)
+
+  def checkColor(board: Board): Option[Color] =
+    checkWhite(board).yes.option(White).orElse(checkBlack(board).yes.option(Black))
+
   def kingSafety(m: Move): Boolean =
     kingThreatened(m.after, m.color).no
 

--- a/test-kit/src/test/scala/CastlingKingSideTest.scala
+++ b/test-kit/src/test/scala/CastlingKingSideTest.scala
@@ -19,7 +19,7 @@ R  QK  R"""
     assertEquals(badHist.destsFrom(E1), Set(F1))
     val board960 = """
 PPPPPPPP
-RQK   R """.chess960.updateHistory(_ => History.castle(White, kingSide = true, queenSide = true))
+RQK   R """.chess960.updateHistory(_ => castleHistory(White, kingSide = true, queenSide = true))
     assertEquals(board960.place(White.bishop, D1).flatMap(_.destsFrom(C1)), Set())
     assertEquals(board960.place(White.knight, F1).flatMap(_.destsFrom(C1)), Set(D1))
   test("possible"):

--- a/test-kit/src/test/scala/CastlingKingSideTest.scala
+++ b/test-kit/src/test/scala/CastlingKingSideTest.scala
@@ -19,7 +19,7 @@ R  QK  R"""
     assertEquals(badHist.destsFrom(E1), Set(F1))
     val board960 = """
 PPPPPPPP
-RQK   R """.chess960.withHistory(History.castle(White, kingSide = true, queenSide = true))
+RQK   R """.chess960.updateHistory(_ => History.castle(White, kingSide = true, queenSide = true))
     assertEquals(board960.place(White.bishop, D1).flatMap(_.destsFrom(C1)), Set())
     assertEquals(board960.place(White.knight, F1).flatMap(_.destsFrom(C1)), Set(D1))
   test("possible"):

--- a/test-kit/src/test/scala/CastlingQueenSideTest.scala
+++ b/test-kit/src/test/scala/CastlingQueenSideTest.scala
@@ -36,7 +36,7 @@ PPPPPPPP
 
   val board = """
 PPPPPPPP
-R   K  R""".updateHistory(_ => History.castle(White, kingSide = true, queenSide = true))
+R   K  R""".updateHistory(_ => castleHistory(White, kingSide = true, queenSide = true))
   test("impact history: if king castles kingside"):
     val game = Game(board, White)
     val g2   = game.playMove(E1, G1).get

--- a/test-kit/src/test/scala/CastlingQueenSideTest.scala
+++ b/test-kit/src/test/scala/CastlingQueenSideTest.scala
@@ -36,7 +36,7 @@ PPPPPPPP
 
   val board = """
 PPPPPPPP
-R   K  R""".withHistory(History.castle(White, kingSide = true, queenSide = true))
+R   K  R""".updateHistory(_ => History.castle(White, kingSide = true, queenSide = true))
   test("impact history: if king castles kingside"):
     val game = Game(board, White)
     val g2   = game.playMove(E1, G1).get

--- a/test-kit/src/test/scala/ChessTest.scala
+++ b/test-kit/src/test/scala/ChessTest.scala
@@ -1,6 +1,7 @@
 package chess
 
 import cats.syntax.all.*
+import chess.variant.Crazyhouse
 
 import scala.language.implicitConversions
 
@@ -90,14 +91,16 @@ trait ChessTestCommon:
       castles: Castles = Castles.init,
       checkCount: CheckCount = CheckCount(0, 0),
       unmovedRooks: UnmovedRooks = UnmovedRooks.corners,
-      halfMoveClock: HalfMoveClock = HalfMoveClock.initial
+      halfMoveClock: HalfMoveClock = HalfMoveClock.initial,
+      crazyData: Option[Crazyhouse.Data] = None
   ) = History(
     lastMove = lastMove,
     positionHashes = positionHashes,
     castles = castles,
     checkCount = checkCount,
     unmovedRooks = unmovedRooks,
-    halfMoveClock = halfMoveClock
+    halfMoveClock = halfMoveClock,
+    crazyData = crazyData
   )
 
 trait MunitExtensions extends munit.FunSuite:

--- a/test-kit/src/test/scala/ChessTest.scala
+++ b/test-kit/src/test/scala/ChessTest.scala
@@ -53,6 +53,10 @@ trait ChessTestCommon:
     def movesAt(s: Square): List[Move] =
       sit.moves.getOrElse(s, Nil)
 
+  def castleHistory(color: Color, kingSide: Boolean, queenSide: Boolean): History =
+    val castles = Castles.init.update(color, kingSide, queenSide)
+    History(castles = castles, unmovedRooks = UnmovedRooks.corners, crazyData = None)
+
   def fenToGameEither(positionString: FullFen, variant: Variant): Either[String, Game] =
     Fen
       .read(variant, positionString)

--- a/test-kit/src/test/scala/PawnTest.scala
+++ b/test-kit/src/test/scala/PawnTest.scala
@@ -97,7 +97,7 @@ class PawnTest extends ChessTest:
     // "with irrelevant history" in:
     assertEquals(
       board
-        .withHistory(
+        .updateHistory(_ =>
           defaultHistory(
             lastMove = Option(Uci.Move(A2, A4))
           )
@@ -108,7 +108,7 @@ class PawnTest extends ChessTest:
     // "with relevant history on the left" in:
     assertEquals(
       board
-        .withHistory(
+        .updateHistory(_ =>
           defaultHistory(
             lastMove = Option(Uci.Move(C7, C5))
           )
@@ -119,7 +119,7 @@ class PawnTest extends ChessTest:
     // "with relevant history on the right" in:
     assertEquals(
       board
-        .withHistory(
+        .updateHistory(_ =>
           defaultHistory(
             lastMove = Option(Uci.Move(E7, E5))
           )
@@ -132,7 +132,7 @@ class PawnTest extends ChessTest:
       makeBoard(
         D5 -> White.pawn,
         E5 -> Black.rook
-      ).withHistory(
+      ).updateHistory(_ =>
         defaultHistory(
           lastMove = Option(Uci.Move(E7, E5))
         )
@@ -144,7 +144,7 @@ class PawnTest extends ChessTest:
       makeBoard(
         D5 -> White.pawn,
         E5 -> White.pawn
-      ).withHistory(
+      ).updateHistory(_ =>
         defaultHistory(
           lastMove = Option(Uci.Move(E7, E5))
         )
@@ -242,7 +242,7 @@ class PawnTest extends ChessTest:
     // "with relevant history on the left" in:
     assertEquals(
       board
-        .withHistory(
+        .updateHistory(_ =>
           defaultHistory(
             lastMove = Option(Uci.Move(C2, C4))
           )
@@ -255,7 +255,7 @@ class PawnTest extends ChessTest:
       makeBoard(
         D4 -> Black.pawn,
         E4 -> White.rook
-      ).withHistory(
+      ).updateHistory(_ =>
         defaultHistory(
           lastMove = Option(Uci.Move(E2, E4))
         )

--- a/test-kit/src/test/scala/format/Visual.scala
+++ b/test-kit/src/test/scala/format/Visual.scala
@@ -31,7 +31,7 @@ object Visual:
       }).flatten,
       variant = chess.variant.Variant.default
     )
-    b.withHistory(History(unmovedRooks = UnmovedRooks.from(b), crazyData = None))
+    b.updateHistory(_ => History(unmovedRooks = UnmovedRooks.from(b), crazyData = None))
 
   def >>(board: Board): String = >>|(board, Map.empty)
 

--- a/test-kit/src/test/scala/format/Visual.scala
+++ b/test-kit/src/test/scala/format/Visual.scala
@@ -31,7 +31,7 @@ object Visual:
       }).flatten,
       variant = chess.variant.Variant.default
     )
-    b.withHistory(History(unmovedRooks = UnmovedRooks.from(b)))
+    b.withHistory(History(unmovedRooks = UnmovedRooks.from(b), crazyData = None))
 
   def >>(board: Board): String = >>|(board, Map.empty)
 
@@ -55,7 +55,10 @@ object Visual:
     val unmovedRooks = if variant.allowsCastling then UnmovedRooks(board.rooks) else UnmovedRooks.none
     Board(
       board,
-      History(castles = variant.castles, unmovedRooks = unmovedRooks),
-      variant,
-      variant.crazyhouse.option(Crazyhouse.Data.init)
+      History(
+        castles = variant.castles,
+        unmovedRooks = unmovedRooks,
+        crazyData = variant.crazyhouse.option(Crazyhouse.Data.init)
+      ),
+      variant
     )

--- a/test-kit/src/test/scala/perft/PerftTest.scala
+++ b/test-kit/src/test/scala/perft/PerftTest.scala
@@ -13,7 +13,7 @@ object PerftTest extends SimpleIOSuite:
     def empty                           = true
     def combine(x: Boolean, y: Boolean) = x && y
 
-  val nodeLimits = 1_000L
+  val nodeLimits = 1_000_000L
 
   test("random.perft"):
     perfts(Perft.randomPerfts, Chess960, 10_000L)
@@ -31,7 +31,7 @@ object PerftTest extends SimpleIOSuite:
     perfts(Perft.atomicPerfts, Atomic, nodeLimits)
       .map(assert(_))
 
-  test("crazyhouse.perft"):
+  test("crazyhouse.perft".only):
     perfts(Perft.crazyhousePerfts, Crazyhouse, nodeLimits)
       .map(assert(_))
 

--- a/test-kit/src/test/scala/perft/PerftTest.scala
+++ b/test-kit/src/test/scala/perft/PerftTest.scala
@@ -13,7 +13,7 @@ object PerftTest extends SimpleIOSuite:
     def empty                           = true
     def combine(x: Boolean, y: Boolean) = x && y
 
-  val nodeLimits = 1_000_000L
+  val nodeLimits = 1_000L
 
   test("random.perft"):
     perfts(Perft.randomPerfts, Chess960, 10_000L)
@@ -31,7 +31,7 @@ object PerftTest extends SimpleIOSuite:
     perfts(Perft.atomicPerfts, Atomic, nodeLimits)
       .map(assert(_))
 
-  test("crazyhouse.perft".only):
+  test("crazyhouse.perft"):
     perfts(Perft.crazyhousePerfts, Crazyhouse, nodeLimits)
       .map(assert(_))
 


### PR DESCRIPTION
Eventually we want to move `history` and `variant` to `Situation`, and use `chess.bitboard.Board` directly from `Situation`.